### PR TITLE
Fixed issue that resulted in segmentation fault for small matrices

### DIFF
--- a/CSR5_avx2/detail/avx2/csr5_spmv_avx2.h
+++ b/CSR5_avx2/detail/avx2/csr5_spmv_avx2.h
@@ -65,11 +65,12 @@ void spmv_csr5_compute_kernel(const iT           *d_column_index,
     const int num_thread = omp_get_max_threads();
     const int chunk = ceil((double)(p-1) / (double)num_thread);
     const int stride_vT = ANONYMOUSLIB_X86_CACHELINE / sizeof(vT);
+    const int num_thread_active = ceil((p-1.0)/chunk);
 
     #pragma omp parallel
     {
         int tid = omp_get_thread_num();
-        iT start_row_start = d_partition_pointer[tid * chunk] & 0x7FFFFFFF;
+        iT start_row_start = tid < num_thread_active ? d_partition_pointer[tid * chunk] & 0x7FFFFFFF : 0;
 
         vT  s_sum[8]; // allocate a cache line
         vT  s_first_sum[8]; // allocate a cache line
@@ -275,7 +276,9 @@ void spmv_csr5_calibrate_kernel(const uiT *d_partition_pointer,
     int num_thread = omp_get_max_threads();
     int chunk = ceil((double)(p-1) / (double)num_thread);
     int stride_vT = ANONYMOUSLIB_X86_CACHELINE / sizeof(vT);
-    int num_cali = num_thread > (p-1) ? (p-1) : num_thread;
+    // calculate the number of maximal active threads (for a static loop scheduling with size chunk)
+    int num_thread_active = ceil((p-1.0)/chunk);
+    int num_cali = num_thread_active < num_thread ? num_thread_active : num_thread;
 
     for (int i = 0; i < num_cali; i++)
     {


### PR DESCRIPTION
The use of small matrices (matrices with a small number of partitions) on systems with a high number of threads result in segmentation fault. These changes should fix the issue.

To reproduce the issue the sherman1 matrix with a thread number of 56 can be used.
